### PR TITLE
Verilator 1port fix

### DIFF
--- a/bin/golden_test.sh
+++ b/bin/golden_test.sh
@@ -246,14 +246,6 @@ else
         done
     done
 
-#     DO_2PORT_ONLY=
-#     if [ "$DO_2PORT_ONLY" ]; then
-#         # Delete all tests except sram=2port
-#         # This hack exists b/c Verilator only works on 2port srams
-#         t2=$(printf '%s\n' "${tests[@]}" | egrep '2port|hline')
-#         mapfile -t tests < <(echo "${t2[@]}")
-#     fi
-
     # Got 1port working, hoory! But dpump still busted.
     if [ "$SKIP_DPUMP" ]; then
         # Delete all tests except sram=1port,2port, i.e. all dpump tests

--- a/bin/golden_test.sh
+++ b/bin/golden_test.sh
@@ -245,11 +245,20 @@ else
         done
     done
 
-    DO_2PORT_ONLY=
-    if [ "$DO_2PORT_ONLY" ]; then
-        # Delete all tests except sram=2port
-        # This hack exists b/c Verilator only works on 2port srams
-        t2=$(printf '%s\n' "${tests[@]}" | egrep '2port|hline')
+#     DO_2PORT_ONLY=
+#     if [ "$DO_2PORT_ONLY" ]; then
+#         # Delete all tests except sram=2port
+#         # This hack exists b/c Verilator only works on 2port srams
+#         t2=$(printf '%s\n' "${tests[@]}" | egrep '2port|hline')
+#         mapfile -t tests < <(echo "${t2[@]}")
+#     fi
+
+    # Got 1port working, hoory! But dpump still busted.
+    SKIP_DPUMP=True
+    if [ "$SKIP_DPUMP" ]; then
+        # Delete all tests except sram=1port,2port, i.e. all dpump tests
+        # This hack exists b/c Verilator still does not work on dpump srams
+        t2=$(printf '%s\n' "${tests[@]}" | grep -v 'dpump')
         mapfile -t tests < <(echo "${t2[@]}")
     fi
 

--- a/bin/golden_test.sh
+++ b/bin/golden_test.sh
@@ -245,6 +245,7 @@ else
         done
     done
 
+    DO_2PORT_ONLY=
     if [ "$DO_2PORT_ONLY" ]; then
         # Delete all tests except sram=2port
         # This hack exists b/c Verilator only works on 2port srams

--- a/bin/golden_test.sh
+++ b/bin/golden_test.sh
@@ -255,7 +255,6 @@ else
 #     fi
 
     # Got 1port working, hoory! But dpump still busted.
-    SKIP_DPUMP=True
     if [ "$SKIP_DPUMP" ]; then
         # Delete all tests except sram=1port,2port, i.e. all dpump tests
         # This hack exists b/c Verilator still does not work on dpump srams
@@ -519,15 +518,18 @@ if [ ! -e $summfile ]; then
 fi
 
 npass=`grep PASS $summfile | wc -l`
-echo "$npass/$ntests tests PASSED"
+note=""
 if [ "$n_allowed_failures" -eq 1 ]; then
-    printf "    (NOTE: One failure is allowed because '8 4 1' not supported.)\n\n"
+    note=" (NOTE: One failure is allowed b/c '8 4 1' not supported.)"
 fi
+echo "$npass/$ntests tests PASSED$note"
 
 npass_expected=$((ntests-n_allowed_failures))
 
 if [ $npass -ne $npass_expected ]; then
     printf "ERROR golden_test.sh - $npass_expected/$npass should PASS\n\n"
+    printf "FINAL RESULT = FAIL\n"
+    exit 13
 fi
 
 echo Warnings:
@@ -541,6 +543,9 @@ echo
 # echo "Result summary is here: '$summfile'"
 /bin/rm $summfile
 echo "NOTE did not keep result summary file '$summfile'"
+
+printf "FINAL RESULT = PASS\n"
+
 
 # echo ==============================================================================
 # cat $summfile

--- a/bin/golden_test.sh
+++ b/bin/golden_test.sh
@@ -447,7 +447,12 @@ for t in "${tests[@]}"; do
     | awk '{print $0 "'" --- $npoints $nunits $nports"'"; }'
 
   keep_abbrev=1
-  if [ "$keep_abbrev" ]; then
+  if [ "$DBG" ]; then
+    echo ""
+    echo "Keeping $tmp for debugging purposes"
+    wc -l $tmp
+    echo ""
+  elif [ "$keep_abbrev" ]; then
     echo ""
     echo "Keeping first 300 lines ONLY of $tmp"
     wc -l $tmp

--- a/bin/golden_test.sh
+++ b/bin/golden_test.sh
@@ -352,6 +352,7 @@ for t in "${tests[@]}"; do
       echo "$sfx not supported (16 SRAM's for 8 points!?)"; continue
   fi
   [ $sfx == "8_4_1port" ] && echo "*** NOTE $sfx is SUPPOSED to fail! (16 SRAM's for 8 points\!?) ***"
+  [ $sfx == "8_4_1port" ] && echo "TR FAIL: But that's okay, $sfx is SUPPOSED to fail! (16 SRAM's for 8 points\!?) ***"
 
   # Print out date, id info
   date; echo $sfx": npoints=$npoints, nunits=$nunits, sram=$sram; alg=$swizzalg; sim=$SIMULATOR"

--- a/bin/golden_test.sh
+++ b/bin/golden_test.sh
@@ -145,6 +145,7 @@ MAKEFILE=$FFTGEN_DIR/Makefile
 
 tests=()
 ntests=1
+n_allowed_failures=0
 
 # simulator can be either vcs or verilator
 SIMULATOR='verilator'
@@ -349,10 +350,10 @@ for t in "${tests[@]}"; do
 
   # "8_4_1port" is not supported (at least for now)
   if [ $sfx == "8_4_1port" ]; then
-      echo "$sfx not supported (16 SRAM's for 8 points!?)"; continue
+      n_allowed_failures=1
+      echo "TR FAIL: Combo not attempted  --- 8 4 1port fail OKAY b/c makes no sense (16 SRAM's for 8 points\!?)"
+      continue
   fi
-  [ $sfx == "8_4_1port" ] && echo "*** NOTE $sfx is SUPPOSED to fail! (16 SRAM's for 8 points\!?) ***"
-  [ $sfx == "8_4_1port" ] && echo "TR FAIL: But that's okay, $sfx is SUPPOSED to fail! (16 SRAM's for 8 points\!?) ***"
 
   # Print out date, id info
   date; echo $sfx": npoints=$npoints, nunits=$nunits, sram=$sram; alg=$swizzalg; sim=$SIMULATOR"
@@ -519,17 +520,14 @@ fi
 
 npass=`grep PASS $summfile | wc -l`
 echo "$npass/$ntests tests PASSED"
-echo "    (NOTE 47/48 pass is normal because '8 4 1' not supported.)"
-echo
+if [ "$n_allowed_failures" -eq 1 ]; then
+    printf "    (NOTE: One failure is allowed because '8 4 1' not supported.)\n\n"
+fi
 
-if [ $ntests == 48 ]; then
-    if [ $npass != 47 ]; then
-        echo "ERROR golden_test.sh - should be 47/48 passes"
-        exit 13
-    fi
-elif [ $npass != $ntests ]; then
-    echo "ERROR golden_test.sh - test(s) failed"
-    exit 13
+npass_expected=$((ntests-n_allowed_failures))
+
+if [ $npass -ne $npass_expected ]; then
+    printf "ERROR golden_test.sh - $npass_expected/$npass should PASS\n\n"
 fi
 
 echo Warnings:

--- a/rtl/SRAM.vp
+++ b/rtl/SRAM.vp
@@ -73,7 +73,8 @@ module `mname`
    output logic [`$data_width-1`:0] rd_data_o; // Read data OUT.
    input  logic [`$data_width-1`:0] wr_data_i; // Write data IN.
 
-   reg [`$data_width-1`:0] mem[0:`$nrows-1`];           // memory cells
+   reg [`$data_width-1`:0] mem[0:`$nrows-1`];  // Memory cells
+   reg  [`$data_width-1`:0] wr_data_i_prev;    // Hack to make true-1port work I guess
 
    //; # For debugging
    //; my $real="63:32"; # Real
@@ -114,21 +115,20 @@ module `mname`
    //////////////////////////////////////////////////////////////////////////////
    // WRITE TRUE_1PORT
    // FIXME use a proper async SRAM (see above)!!! fiddle w/signals outside, in wrapper :(
-   // 
-   // always @(ez_i or wz_i) begin // doesn't work for verilator
-   // always @(ez_i or wz_i) begin // NOT AN EDGE!!!!!!!!!
-   //
-   always @(negedge wz_i) begin // trial/error debugging - saw behavior on (correct) vcs wave
-      if (~ez_i & ~wz_i) begin
+
+   // Want to trigger writes on negedge wz_i
+   always @(negedge clk_i) wr_data_i_prev = wr_data_i; // omg
+   always @(wz_i) begin
+      if (!ez_i && !wz_i) begin
 
          // WRITE TRUE_1PORT
-         mem[addr_i] <= wr_data_i;
+         mem[addr_i] <= wr_data_i_prev;
 
          // WRITE DEBUG
          $display("%m %1d: ez_i=%1d and wz_i=%1d", $time, ez_i, wz_i);
-         $display("%m %1d: Wrote   wr_data_i mem[%1d] <= %16x", $time, addr_i, wr_data_i);
+         $display("%m %1d: Wrote   wr_data_i mem[%1d] <= %16x", $time, addr_i, wr_data_i_prev);
          $display("`$myname` t5 %5d: Wrote(f) wr_data_i mem[%1d] <= (bsr'%08X,bsr'%08X)",
-                       $time, addr_i, `ri("wr_data_i")`);
+                       $time, addr_i, `ri("wr_data_i_prev")`);
          $display("");
       end
    end

--- a/rtl/SRAM.vp
+++ b/rtl/SRAM.vp
@@ -74,7 +74,7 @@ module `mname`
    input  logic [`$data_width-1`:0] wr_data_i; // Write data IN.
 
    reg [`$data_width-1`:0] mem[0:`$nrows-1`];  // Memory cells
-   reg  [`$data_width-1`:0] wr_data_i_prev;    // Hack to make true-1port work I guess
+   reg [`$data_width-1`:0] wr_data_i_prev;     // Hack to make true-1port work I guess
 
    //; # For debugging
    //; my $real="63:32"; # Real

--- a/rtl/fftram.vp
+++ b/rtl/fftram.vp
@@ -591,6 +591,10 @@ module `mname`
    //; foreach my $p ("1", "2") {
    //////////////////////////////////////////////////////////////////////////////
    // SRAM data in`$p` OUT from sram (or bypass buffer) to butterfly unit
+   // OMG note stupid-endian: match[MSB] = match[0] FIXME FIXME FIXME?
+   //   E.g. if there are four srams
+   //     match==8  =>  match[0] == 1  => SRAM000
+   //     match==1  =>  match[3] == 1  => SRAM003
    //
    //;#   assign BFLY0_in1_data_o =                   <=  BUG/FIXME/TODO inaccurate
    //;#      ( BFLY0_op1_match[0] ) ? (bypass000 ? (buf000 : SRAM000_rd_data)) :

--- a/test/test-regress.sh
+++ b/test/test-regress.sh
@@ -117,7 +117,7 @@ if [ "$is_verilator" ]; then
             exit 13
         fi
     fi
-    verilator_caveats; export DO_2PORT_ONLY=1
+    verilator_caveats; export SKIP_DPUMP=1
 fi
 
 # Run the regressions!
@@ -128,11 +128,8 @@ fi
     echo $fftgen/bin/golden_test.sh $*
     $fftgen/bin/golden_test.sh $* \
         |& $nobuf tee test_results.log \
-        |  $nobuf egrep 'PASS|FAIL|ERR'
+        |  $nobuf egrep 'PASS|FAIL|ERR| failure is allowed'
 
     [ "$is_verilator" ] && verilator_caveats
-
-    egrep 'FAIL|ERR' test_results.log && result=FAIL || result=PASS
-    printf "\nFINAL RESULT = $result\n"
-    [ "$result" == PASS ] || exit 13
+    egrep '^FINAL RESULT.*PASS' test_results.log || exit 13
 )

--- a/test/test-regress.sh
+++ b/test/test-regress.sh
@@ -97,7 +97,7 @@ test -d /tmp/fpu$$ && /bin/rm -rf /tmp/fpu$$
 # Prepare to issue caveats in case of verilator version
 function verilator_caveats {
     printf "\n------------------------------------------------------------------------"
-    printf "\nNote that verilator tests only work for 2port sram."
+    printf "\nNote that verilator tests do not (yet) work for double-pump sram."
     printf "\nThis appears to be a verilator bug; all tests pass for vcs (trust me!)"
     printf "\n------------------------------------------------------------------------\n\n"
 }

--- a/tst/top_fft.vp
+++ b/tst/top_fft.vp
@@ -434,10 +434,21 @@ module `mname`( input logic clk, output wire done );
    //
    ////////////////////////////////////
 
+   logic [31:0] clock_counter;
    initial begin
       start = 1'b0; // Should be comb logic based on rst_n etc? leave it for now
       rst_n = 1'b1;
+      clock_counter = 32'b0;
    end
+
+   ////////////////////////////////////////////////////////////////////////
+   // clock counter I guess
+   //
+
+   always @ (posedge clk) begin
+     clock_counter <= clock_counter + 32'b1;
+   end
+
 
    // note cgra does this:
    //  always @(posedge clk or posedge reset) begin

--- a/tst/top_fft.vp
+++ b/tst/top_fft.vp
@@ -434,21 +434,10 @@ module `mname`( input logic clk, output wire done );
    //
    ////////////////////////////////////
 
-   logic [31:0] clock_counter;
    initial begin
       start = 1'b0; // Should be comb logic based on rst_n etc? leave it for now
       rst_n = 1'b1;
-      clock_counter = 32'b0;
    end
-
-   ////////////////////////////////////////////////////////////////////////
-   // clock counter I guess
-   //
-
-   always @ (posedge clk) begin
-     clock_counter <= clock_counter + 32'b1;
-   end
-
 
    // note cgra does this:
    //  always @(posedge clk or posedge reset) begin


### PR DESCRIPTION
* Rewrote SRAM to make 1-port variant work with both VCS and Verilator.

* Added 1port-sram variation to regression test, verilator can now do both 1- and 2-port SRAMs.